### PR TITLE
Remove redundant npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "core-js": "^2.5.4",
     "font-awesome": "^4.7.0",
     "jwt-decode": "latest",
-    "npm": "^6.4.0",
     "rxjs": "6.1.0",
     "rxjs-compat": "6.1.0",
     "web-animations-js": "^2.3.1",


### PR DESCRIPTION

Hello apristina!

It seems like you have npm as one of your (dev-) dependency in Frontend.
Since you actually need npm to install the dependencies it's redundant to
have npm itself as (dev-) dependency. 

Therefore I've removed it and made this PR, merge if you want :)
Be sure to re-run `npm i` or `yarn` to actualize your lock files.

Beep boop, I'm a bot.
